### PR TITLE
Revamp 'post active settings' feature. Works very nice now!

### DIFF
--- a/modules/database.py
+++ b/modules/database.py
@@ -158,8 +158,8 @@ class Database(BaseFileMemory):
         self.announce_channels:list[int]
         self.main_channels:list[int]
         self.voice_channels:dict[str, int]
-        self.settings_channels:dict[str, int]
-        self.sent_settings:dict[str, int]
+        self.settings_channels:dict[int, int]
+        self.settings_sent:dict[dict[str, int]]
         self.warned_once:dict[str, bool]
 
         super().__init__(shared_path.database, version=2, missing_okay=True)
@@ -196,12 +196,13 @@ class Database(BaseFileMemory):
         self.main_channels = data.pop('main_channels', [])
         self.voice_channels = data.pop('voice_channels', {})
         self.settings_channels = data.pop('settings_channels', {})
-        self.sent_settings = data.pop('sent_settings', {})
+        self.settings_sent = data.pop('settings_sent', {})
         data['warned_once'] = {}
 
     def save_pre_process(self, data):
         data.pop('warned_once', None)
         return data
+
 
     # Last messages logging
     def get_member_dict(self, member:str) -> dict:
@@ -234,6 +235,7 @@ class Database(BaseFileMemory):
 
         return max(last_user_msg, last_bot_msg) # Return most recent from any user/bot
 
+
     # Warning log management
     def was_warned(self, flag_name):
         return self.warned_once.get(flag_name, False)
@@ -241,44 +243,46 @@ class Database(BaseFileMemory):
     def update_was_warned(self, flag_name, value=True):
         self.warned_once[flag_name] = value
 
+
     # Voice channels management
     def update_voice_channels(self, guild_id, channel_id, save_now=True):
         self.voice_channels[guild_id] = channel_id
         if save_now:
             self.save()
     
-    # Settings channels management (channel where new/updated settings will be posted)
-    def update_settings_channels(self, guild_id, channel_id, save_now=True) -> int|None:
-        old_channel_id = self.settings_channels.get(guild_id)
-        self.settings_channels[guild_id] = channel_id
-        if save_now:
-            self.save()
-        return old_channel_id
 
-    def get_settings_channel_id_for_guild(self, guild_id) -> int:
+    # Settings channels management (channel where new/updated settings will be posted)
+    def get_settings_channel_id_for(self, guild_id:int) -> int:
         return self.settings_channels.get(guild_id)
 
-    # Post active settings feature management
-    def get_settings_msgs_for_guild(self, guild_id:int, key:str|None=None) -> list|dict:
-        sent_settings:dict = self.sent_settings.get(guild_id)
-        if not sent_settings:
-            return None # No channel ever set
-        if not key:
-            return sent_settings # return entire dict
-
-        guild_settings_channel = self.settings_channels.get(guild_id)
-        # create key if not yet existing
-        old_msg_ids_list = sent_settings.setdefault(key, [])
-        return guild_settings_channel, old_msg_ids_list
-
-    def update_settings_key_msgs_for_guild(self, guild_id, key:str, new_msg_ids:list, save_now=True):
-        key_settings = self.get_settings_msgs_for_guild(guild_id, key)
-        if not key_settings:
-            return
-        # Update key value with new msg ids list
-        key_settings = new_msg_ids
+    def update_settings_channel(self, guild_id:int, new_channel_id:int, save_now=True):
+        self.settings_channels[guild_id] = new_channel_id
+        self.settings_sent[guild_id] = {}
         if save_now:
             self.save()
+
+
+    # Post active settings feature management
+    def get_settings_msgs_for(self, guild_id:int, key:str|None=None) -> None|dict|list:
+        settings_sent:dict|None = self.settings_sent.get(guild_id)
+        if settings_sent is None:
+            return None # No channel ever set
+        if not key:
+            return settings_sent # return entire dict
+
+        # create key if not yet existing
+        old_msg_ids_list = self.settings_sent[guild_id].setdefault(key, [])
+        return old_msg_ids_list
+
+    def update_settings_key_msgs_for(self, guild_id, key:str, new_msg_ids:list, save_now=True):
+        settings_key = self.get_settings_msgs_for(guild_id, key)
+        if settings_key is None:
+            return
+        # Update settings key value with new msg ids list
+        self.settings_sent[guild_id][key] = new_msg_ids
+        if save_now:
+            self.save()
+
 
 class Config(BaseFileMemory):
     def __init__(self) -> None:

--- a/settings_templates/config.yaml
+++ b/settings_templates/config.yaml
@@ -23,7 +23,7 @@ discord:
       flows: true   # Embeds for the Flows feature
   # Feature for bot to copy current settings in a dedicated channel when changing settings via commands (ei: /imgmodel).
   post_active_settings:
-    enabled: false # When enabled, you can set a "Settings Channel" for each server the bot is in via command '/set_server_settings_channel'
+    enabled: true # When enabled, you can set a "Settings Channel" for each server the bot is in via command '/set_server_settings_channel'
     post_settings_for: ['behavior', 'character', 'tags', 'imgmodel', 'llmstate'] # Limit the settings to be posted by removing them from list.
   # Feature for bot to automatically send a copy of image to starboard channel.
   starboard:

--- a/settings_templates/config.yaml
+++ b/settings_templates/config.yaml
@@ -21,10 +21,10 @@ discord:
       images: true  # Embeds related to image generation
       changes: true # Embeds related to character / model changes
       flows: true   # Embeds for the Flows feature
-  # Feature for bot to copy current settings in a dedicated channel when changing settings via commands (ei: /imgmodel),
+  # Feature for bot to copy current settings in a dedicated channel when changing settings via commands (ei: /imgmodel).
   post_active_settings:
-    enabled: false
-    target_channel_id: 11111111111111111111 # Bot requires permissions to message this channel.
+    enabled: false # When enabled, you can set a "Settings Channel" for each server the bot is in via command '/set_server_settings_channel'
+    post_settings_for: ['behavior', 'character', 'tags', 'imgmodel', 'llmstate'] # Limit the settings to be posted by removing them from list.
   # Feature for bot to automatically send a copy of image to starboard channel.
   starboard:
     enabled: true


### PR DESCRIPTION
The feature is now compatible with multiple servers, with a new command to designate the settings channel for each one.
It is very smart about managing the messages it sent now - categorizing the settings it posts, and only deleting / replacing relevant categories when settings are modified.